### PR TITLE
chore: update GoReleaser configuration to reflect new project name

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -26,7 +26,7 @@ archives:
 release:
   github:
     owner: nsnarender5511
-    name: crules
+    name: cpp
   draft: false
   prerelease: auto
   mode: replace  # Replaces existing releases
@@ -38,7 +38,7 @@ brews:
   - repository:
       owner: nsnarender5511
       name: homebrew-tap
-    homepage: https://github.com/nsnarender5511/crules
+    homepage: https://github.com/nsnarender5511/cpp
     description: "A tool for managing and synchronizing Cursor rules across multiple projects"
     license: MIT
     test: |
@@ -48,13 +48,13 @@ scoops:
   - repository:
       owner: nsnarender5511
       name: scoop-bucket
-    homepage: https://github.com/nsnarender5511/crules
+    homepage: https://github.com/nsnarender5511/cpp
     description: "A tool for managing and synchronizing Cursor rules across multiple projects"
     license: MIT
 
 nfpms:
   - vendor: nsnarender5511
-    homepage: https://github.com/nsnarender5511/crules
+    homepage: https://github.com/nsnarender5511/cpp
     maintainer: nsnarender5511
     description: "A tool for managing and synchronizing Cursor rules across multiple projects"
     license: MIT


### PR DESCRIPTION
- Change all occurrences of "crules" to "cpp" in the GoReleaser YAML file.
- Update GitHub repository links for consistency with the new branding.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated project branding for consistency. The project has been rebranded to "cpp" with all associated homepage references updated across release channels. These changes ensure a uniform and clear experience when accessing release information, streamlining documentation across distribution platforms and enhancing overall project coherence. Improved clarity for all users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->